### PR TITLE
Added port number handling to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,9 @@ $ export IMAGE=docker.perl-app.example
 $ git clone git@github.com:moltar/$IMAGE.git
 $ cd $IMAGE
 $ docker build -t $IMAGE .
-$ docker run --rm $IMAGE
+$ docker run --rm -p5000:5000 $IMAGE
 ```
+
+And direct your browser to:
+
+`http://localhost:5000/`


### PR DESCRIPTION
Added port number handling to the documentation so the exposed port is made accessible

The exposed port number is listed in the `Dockerfile`, but has to be specified on the command line as well.

jonasbn